### PR TITLE
Change type for children from ReactElement to ReactNode

### DIFF
--- a/src/FeedbackFish.tsx
+++ b/src/FeedbackFish.tsx
@@ -1,17 +1,17 @@
-import React, { FunctionComponent, ReactElement } from "react"
+import React, { FunctionComponent, ReactNode } from "react"
 
 import { useFeedbackFish } from "./useFeedbackFish"
 
 type Props = {
   projectId: Parameters<typeof useFeedbackFish>[0]
-  children?: ReactElement | ((props: object) => ReactElement)
+  children?: ReactNode | ((props: object) => ReactNode)
   userId?: string
   metadata?: {
     [key: string]: string
   }
 }
 
-export const FeedbackFish: FunctionComponent<Props> = (props) => {
+export const FeedbackFish: FunctionComponent<Props> = (props: Props) => {
   useFeedbackFish(props.projectId)
 
   if (!props.children) return null


### PR DESCRIPTION
This is a small change to the typings for the `FeedbackFish` component. Using `ReactNode` allows `null` or `false` to be passed as a valid child (in order to disable the widget without unmounting the component).e.g -
```tsx
<FeedbackFish projectId="abcde">
    {canSubmitFeedback && (
        <Button>Feedback!</Button>
    )}
</FeedbackFish>
```